### PR TITLE
Columns quoting bug for PostgreSQL

### DIFF
--- a/framework/db/ActiveRelationTrait.php
+++ b/framework/db/ActiveRelationTrait.php
@@ -438,7 +438,7 @@ trait ActiveRelationTrait
             }
             if (isset($alias)) {
                 foreach ($attributes as $i => $attribute) {
-                    $attributes[$i] = "$alias.$attribute";
+                    $attributes[$i] = "$alias.{{{$attribute}}}";
                 }
             }
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | yes |

In case using PostgreSQL, when relation columns have names in CalmeCase format, there is an error - db don't find selected column. We think, that there must be auto-quoting for columns names.
